### PR TITLE
fix: Ensure device name is properly configured and server started

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
-      with:
-        submodules: 'recursive'
 
     - name: Run static analysis
       uses: esp-cpp/StaticAnalysis@master
@@ -27,4 +25,4 @@ jobs:
         esp_idf_version: release/v5.4
 
         # (Optional) cppcheck args
-        cppcheck_args: -i$GITHUB_WORKSPACE/components/espp -i$GITHUB_WORKSPACE/components/gui/generated --force --enable=all --inline-suppr --inconclusive --platform=mips32 --std=c++17 --suppressions-list=$GITHUB_WORKSPACE/suppressions.txt
+        cppcheck_args: -i$GITHUB_WORKSPACE/components/gui/generated --check-level=exhaustive --force --enable=all --inline-suppr --inconclusive --platform=mips32 --std=c++17 --suppressions-list=$GITHUB_WORKSPACE/suppressions.txt

--- a/components/switch_pro/src/switch_pro.cpp
+++ b/components/switch_pro/src/switch_pro.cpp
@@ -9,9 +9,9 @@ const DeviceInfo SwitchPro::device_info = {.vid = SwitchPro::vid,
                                            .serial_number = SwitchPro::serial};
 
 void SwitchPro::set_report_data(uint8_t report_id, const uint8_t *data, size_t len) {
-  std::vector<uint8_t> data_vec(data, data + len);
   switch (report_id) {
   case input_report_.ID: {
+    std::vector<uint8_t> data_vec(data, data + len);
     std::lock_guard<std::recursive_mutex> lock(input_report_mutex_);
     input_report_.set_data(data_vec);
     break;

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -34,6 +34,6 @@ dependencies:
 direct_dependencies:
 - espressif/esp_tinyusb
 - idf
-manifest_hash: 1a3d4b0b5fbc6394cb597c0569d0925a2658a23b6265130d0d98c8ff1d630a6b
+manifest_hash: ba5de247b9599f1f3dbc9787db5deaffe9e06879e6a028bd4fcb5e7a7e705c1d
 target: esp32s3
 version: 2.0.0

--- a/main/ble.cpp
+++ b/main/ble.cpp
@@ -99,6 +99,9 @@ class ScanCallbacks : public NimBLEScanCallbacks {
       should_connect = true;
     }
     if (should_connect) {
+      /** stop scan before connecting */
+      NimBLEDevice::getScan()->stop();
+
       logger.info("Found Our Device");
 
       /** Async connections can be made directly in the scan callbacks */
@@ -186,8 +189,10 @@ static bool timer_callback() {
   return false; // don't stop the timer
 }
 
-void init_ble() {
-  NimBLEDevice::init("ESP-USB-BLE-HID");
+void init_ble(const std::string &device_name) {
+  NimBLEDevice::init(device_name);
+  static auto server_ = NimBLEDevice::createServer();
+  server_->start();
 
   // // and some i/o config
   auto io_capabilities = BLE_HS_IO_NO_INPUT_OUTPUT;

--- a/main/ble.cpp
+++ b/main/ble.cpp
@@ -99,7 +99,8 @@ class ScanCallbacks : public NimBLEScanCallbacks {
       should_connect = true;
     }
     if (should_connect) {
-      /** stop scan before connecting */
+      /** stop scan before connecting, since we use async connections and don't
+          want to possibly try to connect to multiple devices. */
       NimBLEDevice::getScan()->stop();
 
       logger.info("Found Our Device");
@@ -191,6 +192,8 @@ static bool timer_callback() {
 
 void init_ble(const std::string &device_name) {
   NimBLEDevice::init(device_name);
+  // NOTE: you must create a server if you want the GAP services to be available
+  // and the device name to be readable by connected peers.
   static auto server_ = NimBLEDevice::createServer();
   server_->start();
 

--- a/main/ble.hpp
+++ b/main/ble.hpp
@@ -9,7 +9,7 @@
 
 typedef NimBLERemoteCharacteristic::notify_callback notify_callback_t;
 
-void init_ble();
+void init_ble(const std::string &device_name);
 void start_ble_reconnection_thread(notify_callback_t callback);
 void start_ble_pairing_thread(notify_callback_t callback);
 bool is_ble_subscribed();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -132,7 +132,8 @@ extern "C" void app_main(void) {
 
   // MARK: BLE initialization
   logger.info("BLE initialization");
-  init_ble();
+  std::string device_name = "Switch";
+  init_ble(device_name);
 
   logger.info("Scanning for peripherals");
   start_ble_reconnection_thread(notifyCB);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update espp to latest
* We want to ensure remote devices can properly read our name, so ensure a server is created and it is started
* Update the name of this device to simply be `Switch` since that is the primary use case
* allow ble init to take device name for clearer code

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ensures our name is properly configured

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run on `t-dongle-s3`, ensure remote can read our name

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
