### PR TITLE
fix: Only pair to gamepads, and set conn params after connection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ set(EXTRA_COMPONENT_DIRS
 
 set(
   COMPONENTS
-  "main esptool_py driver logger math task hid-rp hid_service esp-nimble-cpp espcoredump gui qtpy task t-dongle-s3 xbox switch_pro"
+  "main esptool_py driver logger math task hid-rp hid_service esp-nimble-cpp ble_gatt_server espcoredump gui qtpy task t-dongle-s3 xbox switch_pro"
   CACHE STRING
   "List of components to include"
   )

--- a/main/ble.hpp
+++ b/main/ble.hpp
@@ -4,6 +4,7 @@
 
 #include <NimBLEDevice.h>
 
+#include "ble_appearances.hpp"
 #include "hid_service.hpp"
 #include "timer.hpp"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update to set connection parameters after connection instead of before
* Update to only pair if the advertised device is a gamepad
* Set auto delete on client

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes some possible connection / reconnection related bugs Ensures it doesnt connect to non-gamepad hid devices

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run on t-dongle s3

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
