### PR TITLE
feat: Generate random SP serial number each boot

### DIFF
--- a/components/gamepad_inputs/include/gamepad_inputs.hpp
+++ b/components/gamepad_inputs/include/gamepad_inputs.hpp
@@ -56,8 +56,8 @@ struct GamepadInputs {
         uint8_t dpad_right : 1; // overlapped with right
         uint8_t : 2;
         // byte 2
-        uint8_t minus : 1; // overlapped with select
         uint8_t plus : 1;  // overlapped with start
+        uint8_t minus : 1; // overlapped with select
         uint8_t right_sr : 1;
         uint8_t right_sl : 1;
         uint8_t left_sr : 1;

--- a/components/switch_pro/src/switch_pro.cpp
+++ b/components/switch_pro/src/switch_pro.cpp
@@ -1,12 +1,6 @@
 #include "switch_pro.hpp"
 
-const DeviceInfo SwitchPro::device_info = {.vid = SwitchPro::vid,
-                                           .pid = SwitchPro::pid,
-                                           .bcd = SwitchPro::bcd,
-                                           .usb_bcd = SwitchPro::usb_bcd,
-                                           .manufacturer_name = SwitchPro::manufacturer,
-                                           .product_name = SwitchPro::product,
-                                           .serial_number = SwitchPro::serial};
+#include <esp_random.h>
 
 void SwitchPro::set_report_data(uint8_t report_id, const uint8_t *data, size_t len) {
   switch (report_id) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update to not use same serial number for device info, hopefully supporting multiple devices on the same switch
* Fix mapping of minus/plus which were inverted

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Could not get two dongles to both work on the same switch at the same time, hopefully unique serial numbers fixes that.

I also noticed I had mapped minus/plus backwards in testing.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run `main` on t-dongle-s3 and ensure it still works with switch

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
