### PR TITLE
fix: Update usb_bcd and keep static usb serial number

### DIFF
--- a/components/switch_pro/include/switch_pro.hpp
+++ b/components/switch_pro/include/switch_pro.hpp
@@ -54,21 +54,10 @@ public:
     // if the serial number is < 16 bytes, fill the remaining bytes out of 16 with 0x00
     std::fill(spi_rom_factory_data.begin() + std::size(serial), spi_rom_factory_data.begin() + 16,
               0x00);
-
-    // set the device info
-    device_info_ = {
-        .vid = SwitchPro::vid,
-        .pid = SwitchPro::pid,
-        .bcd = SwitchPro::bcd,
-        .usb_bcd = SwitchPro::usb_bcd,
-        .manufacturer_name = SwitchPro::manufacturer,
-        .product_name = SwitchPro::product,
-        .serial_number = serial,
-    };
   }
 
   // Info
-  virtual const DeviceInfo &get_device_info() const override { return device_info_; }
+  virtual const DeviceInfo &get_device_info() const override { return device_info; }
 
   // Report Data
   virtual uint8_t get_input_report_id() const override { return InputReport::ID; }
@@ -95,13 +84,14 @@ protected:
 
   static constexpr uint64_t counter_period_us = 4960; // Joy-Con uses 4.96ms as the timer tick rate
 
-  static constexpr uint16_t usb_bcd = 0x0100;
+  static constexpr uint16_t usb_bcd = 0x0200;
   static constexpr uint16_t vid = 0x057E;
   static constexpr uint16_t pid = 0x2009;
   static constexpr uint16_t bcd = 0x0200;
 
   static constexpr const char manufacturer[] = "Nintendo Co., Ltd.";
   static constexpr const char product[] = "Pro Controller";
+  static constexpr const char usb_serial_number[] = "000000000001";
 
   GamepadDevice::ReportData process_command(const uint8_t *data, size_t len);
   void set_subcommand_reply(std::vector<uint8_t> &report);
@@ -128,7 +118,7 @@ protected:
   /// @return num bytes read
   uint8_t spi_read_impl(uint8_t bank, uint8_t reg, uint8_t read_length, uint8_t *response);
 
-  DeviceInfo device_info_;
+  static const DeviceInfo device_info;
 
   std::array<uint8_t, std::size(sp::spi_rom_data_60)> spi_rom_factory_data;
   std::array<uint8_t, std::size(sp::spi_rom_data_80)> spi_rom_user_data;

--- a/components/switch_pro/src/switch_pro.cpp
+++ b/components/switch_pro/src/switch_pro.cpp
@@ -1,6 +1,14 @@
 #include "switch_pro.hpp"
 
-#include <esp_random.h>
+const DeviceInfo SwitchPro::device_info{
+    .vid = SwitchPro::vid,
+    .pid = SwitchPro::pid,
+    .bcd = SwitchPro::bcd,
+    .usb_bcd = SwitchPro::usb_bcd,
+    .manufacturer_name = SwitchPro::manufacturer,
+    .product_name = SwitchPro::product,
+    .serial_number = SwitchPro::usb_serial_number,
+};
 
 void SwitchPro::set_report_data(uint8_t report_id, const uint8_t *data, size_t len) {
   switch (report_id) {

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -30,7 +30,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.4.0
+    version: 5.4.1
 direct_dependencies:
 - espressif/esp_tinyusb
 - idf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* Update usb bcd to be 0x0200 instead of 0x0100 to match official pro controller
* Update usb serial number to match "000000000001" to match official pro controller

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Better spoofs the real controller

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Build and run `main` on t-dongle-s3.

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
- [x] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI

### Software
<!-- Delete this section if not relevant to your PR  -->
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My code follows the code style of this project.
