### PR TITLE
ci: Use new packaged programmer exectuable action make 1-click programmer executables

### DIFF
--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -13,6 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
 
+    outputs:
+      zipfile-id: ${{ steps.zip_step.outputs.artifact-id }}
+
     steps:
     - name: Checkout repo
       uses: actions/checkout@v4
@@ -29,6 +32,7 @@ jobs:
 
     - name: Upload Build Outputs
       uses: actions/upload-artifact@v4
+      id: zip_step
       with:
         name: build-artifacts
         path: |
@@ -50,3 +54,14 @@ jobs:
           build/partition_table/partition-table.bin
           build/flasher_args.json
           build/flash_args
+
+  package_macos:
+    needs: build
+    runs-on: macos-latest
+    name: Package the binaries into an executable for MacOS Systems
+    steps:
+      - uses: esp-cpp/esp-packaged-programmer-action@9ea3c79fb386739e33153acf29b639e8c6631c2e
+        id: macos-package
+        with:
+          zipfile-id: ${{ needs.build.outputs.zipfile-id }}
+          programmer-name: 'esp-usb-ble-hid_programmer'

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -63,7 +63,7 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@b38cb538b5bdbf76cac7ea8b65f9c7b0eb96e694
+      - uses: esp-cpp/esp-packaged-programmer-action@a418ade683f2cbc33f43170a8af7e937ff46cbfd
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}
           programmer-name: 'esp-usb-ble-hid_programmer'

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -63,7 +63,7 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@53ececd5864b256a52d94214e18b43d1d83dd497
+      - uses: esp-cpp/esp-packaged-programmer-action@v1
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}
           programmer-name: 'esp-usb-ble-hid_programmer'

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -63,7 +63,7 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@4ca945488f7cbdfd00354e3299d4bc82a7d19c2f
+      - uses: esp-cpp/esp-packaged-programmer-action@c20ced1
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}
           programmer-name: 'esp-usb-ble-hid_programmer'

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: macos-latest
     name: Package the binaries into an executable for MacOS Systems
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@5abc06a115ed15e6de9efcc0afbbd631aa5f332d
+      - uses: esp-cpp/esp-packaged-programmer-action@3f20e527611642bdb9b24f85072f2720d7add295
         id: macos-package
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: macos-latest
     name: Package the binaries into an executable for MacOS Systems
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@f27311fa80ab0d33b18fcd71fcf950405b753e73
+      - uses: esp-cpp/esp-packaged-programmer-action@8685f45618f8726d92700632aabcf0a42677df95
         id: macos-package
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -63,7 +63,7 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@358f264
+      - uses: esp-cpp/esp-packaged-programmer-action@358f2645babd07079d7da8293625918a6b4937d7
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}
           programmer-name: 'esp-usb-ble-hid_programmer'

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -63,7 +63,7 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@d23ee2af883f464bf6c635d4519a56a224358632
+      - uses: esp-cpp/esp-packaged-programmer-action@574b4edb3fbd9b33894aa87e705f3454acd247d9
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}
           programmer-name: 'esp-usb-ble-hid_programmer'

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: macos-latest
     name: Package the binaries into an executable for MacOS Systems
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@990ba966e245dbe728c48cce73a1cb19d65d8707
+      - uses: esp-cpp/esp-packaged-programmer-action@0ba6672e006b5820a163e9b308a15a7a8736b2af
         id: macos-package
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -63,7 +63,7 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@c20ced1
+      - uses: esp-cpp/esp-packaged-programmer-action@358f264
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}
           programmer-name: 'esp-usb-ble-hid_programmer'

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: macos-latest
     name: Package the binaries into an executable for MacOS Systems
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@9ea3c79fb386739e33153acf29b639e8c6631c2e
+      - uses: esp-cpp/esp-packaged-programmer-action@5c60cda
         id: macos-package
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -55,13 +55,15 @@ jobs:
           build/flasher_args.json
           build/flash_args
 
-  package_macos:
+  package:
+    name: Package the binaries into an executables for Windows, MacOS, and Linux (Ubuntu)
     needs: build
-    runs-on: macos-latest
-    name: Package the binaries into an executable for MacOS Systems
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@8685f45618f8726d92700632aabcf0a42677df95
-        id: macos-package
+      - uses: esp-cpp/esp-packaged-programmer-action@b38cb538b5bdbf76cac7ea8b65f9c7b0eb96e694
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}
           programmer-name: 'esp-usb-ble-hid_programmer'

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: macos-latest
     name: Package the binaries into an executable for MacOS Systems
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@5c60cda
+      - uses: esp-cpp/esp-packaged-programmer-action@990ba966e245dbe728c48cce73a1cb19d65d8707
         id: macos-package
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -63,7 +63,7 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@adf80c276bbc72e4708f0dab23a0a0af6901ef7d
+      - uses: esp-cpp/esp-packaged-programmer-action@4ca945488f7cbdfd00354e3299d4bc82a7d19c2f
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}
           programmer-name: 'esp-usb-ble-hid_programmer'

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -63,7 +63,7 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@358f2645babd07079d7da8293625918a6b4937d7
+      - uses: esp-cpp/esp-packaged-programmer-action@53ececd5864b256a52d94214e18b43d1d83dd497
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}
           programmer-name: 'esp-usb-ble-hid_programmer'

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: macos-latest
     name: Package the binaries into an executable for MacOS Systems
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@3f20e527611642bdb9b24f85072f2720d7add295
+      - uses: esp-cpp/esp-packaged-programmer-action@e0bfabce6886f217a824b7be0f13e0eb3fa0cf5e
         id: macos-package
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -63,7 +63,7 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@a418ade683f2cbc33f43170a8af7e937ff46cbfd
+      - uses: esp-cpp/esp-packaged-programmer-action@b1f16460fa68bed06d36949fb02c1db282fe9562
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}
           programmer-name: 'esp-usb-ble-hid_programmer'

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: macos-latest
     name: Package the binaries into an executable for MacOS Systems
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@0ba6672e006b5820a163e9b308a15a7a8736b2af
+      - uses: esp-cpp/esp-packaged-programmer-action@5abc06a115ed15e6de9efcc0afbbd631aa5f332d
         id: macos-package
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -63,7 +63,7 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@b1f16460fa68bed06d36949fb02c1db282fe9562
+      - uses: esp-cpp/esp-packaged-programmer-action@0ec63bbc5d74b0ab65cd9b54310177b79b6b0b9b
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}
           programmer-name: 'esp-usb-ble-hid_programmer'

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -63,7 +63,7 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@574b4edb3fbd9b33894aa87e705f3454acd247d9
+      - uses: esp-cpp/esp-packaged-programmer-action@adf80c276bbc72e4708f0dab23a0a0af6901ef7d
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}
           programmer-name: 'esp-usb-ble-hid_programmer'

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -63,7 +63,7 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@v1
+      - uses: esp-cpp/esp-packaged-programmer-action@v1.0.0
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}
           programmer-name: 'esp-usb-ble-hid_programmer'

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: macos-latest
     name: Package the binaries into an executable for MacOS Systems
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@e0bfabce6886f217a824b7be0f13e0eb3fa0cf5e
+      - uses: esp-cpp/esp-packaged-programmer-action@f27311fa80ab0d33b18fcd71fcf950405b753e73
         id: macos-package
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}

--- a/.github/workflows/package_main.yml
+++ b/.github/workflows/package_main.yml
@@ -63,7 +63,7 @@ jobs:
         os: [windows-latest, macos-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: esp-cpp/esp-packaged-programmer-action@0ec63bbc5d74b0ab65cd9b54310177b79b6b0b9b
+      - uses: esp-cpp/esp-packaged-programmer-action@d23ee2af883f464bf6c635d4519a56a224358632
         with:
           zipfile-id: ${{ needs.build.outputs.zipfile-id }}
           programmer-name: 'esp-usb-ble-hid_programmer'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Tests using https://github.com/esp-cpp/esp-packaged-programmer-action to package the binaries into executables for easier use.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows users who don't have esp-idf set up to simply download and run the executable to program dongles they buy on Amazon.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Running the workflow manually on this PR:

https://github.com/finger563/esp-usb-ble-hid/actions/runs/14887230694

## Screenshots (if appropriate, e.g. schematic, board, console logs, lab pictures):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update
- [ ] Software change

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My change requires a change to the documentation.
- [ ] I have added / updated the documentation related to this change via either README or WIKI
